### PR TITLE
Chore/improve graphql security

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,12 @@ jobs:
         with:
           node-version: "12"
       - uses: actions/checkout@v2
-      - uses: borales/actions-yarn@v2.0.0
+      - uses: actions/setup-node@v2-beta
         with:
           cmd: install
-      - uses: borales/actions-yarn@v2.0.0
+      - uses: actions/setup-node@v2-beta
         with:
           cmd: lint
-      - uses: borales/actions-yarn@v2.0.0
+      - uses: actions/setup-node@v2-beta
         with:
           cmd: test

--- a/graphql/permissions/index.ts
+++ b/graphql/permissions/index.ts
@@ -1,4 +1,4 @@
-import { rule, allow, deny, or } from "nexus-plugin-shield";
+import { rule, allow } from "nexus-plugin-shield";
 import { getUserId } from "../utils/user";
 
 const isAuthenticated = rule({ cache: "contextual" })(
@@ -11,6 +11,9 @@ const isAuthenticated = rule({ cache: "contextual" })(
 const isAdmin = rule({ cache: "contextual" })(
   async (parent, args, ctx: NexusContext, info) => {
     const userId = getUserId(ctx.token);
+    if (!userId) {
+      return false;
+    }
     const user = await ctx.db.user.findOne({
       where: {
         id: userId,
@@ -32,10 +35,62 @@ const rules = {
     pages: allow,
     blogPosts: allow,
   },
-  Mutations: {
-    adminCreateOneBlogPost: isAdmin,
-    login: allow,
+  Mutation: {
+    "*": isAdmin,
     signup: allow,
+    login: allow,
+    logout: allow,
+  },
+  User: {
+    id: allow,
+    email: isAuthenticated,
+    roles: isAdmin,
+    blogPosts: isAuthenticated,
+  },
+  UserRole: {
+    id: isAuthenticated,
+    users: isAdmin,
+  },
+  BlogPost: {
+    id: allow,
+    title: allow,
+    content: allow,
+    author: allow,
+    authorId: allow,
+    published: isAdmin,
+  },
+  Page: {
+    id: allow,
+    published: isAdmin,
+    createdAt: isAdmin,
+    path: allow,
+    slug: allow,
+    sortKey: isAdmin,
+    parentPageId: isAdmin,
+    parentPage: isAdmin,
+    childPages: isAdmin,
+    navigationTitle: allow,
+    navigationTitle_en: isAdmin,
+    navigationTitle_de: isAdmin,
+    htmlTitle: allow,
+    htmlTitle_en: isAdmin,
+    htmlTitle_de: isAdmin,
+    content: allow,
+
+    meta_description: allow,
+    meta_description_en: isAdmin,
+    meta_description_de: isAdmin,
+
+    social_description: allow,
+    social_description_en: isAdmin,
+    social_description_de: isAdmin,
+
+    social_title: allow,
+    social_title_en: isAdmin,
+    social_title_de: isAdmin,
+  },
+  LoginResult: {
+    user: allow,
   },
 };
 

--- a/graphql/schema.ts
+++ b/graphql/schema.ts
@@ -1,7 +1,7 @@
-import { schema, use, settings, server } from "nexus";
+import { schema, use, settings } from "nexus";
 
 import { prisma } from "nexus-plugin-prisma";
-import { shield } from "nexus-plugin-shield";
+import { deny, shield } from "nexus-plugin-shield";
 import { auth } from "nexus-plugin-jwt-auth";
 
 import { APP_SECRET } from "./utils/user";
@@ -54,6 +54,8 @@ use(
     rules,
     options: {
       allowExternalErrors: true,
+      fallbackRule: deny,
+      debug: true,
     },
   })
 );

--- a/graphql/schema.ts
+++ b/graphql/schema.ts
@@ -22,9 +22,6 @@ schema.addToContext(({ req, res }) => {
 
 settings.change({
   server: {
-    graphql: {
-      introspection: true,
-    },
     playground: {
       settings: {
         "request.credentials": "include",

--- a/src/modules/layout/components/stories/MainMenu.stories.tsx
+++ b/src/modules/layout/components/stories/MainMenu.stories.tsx
@@ -1,16 +1,10 @@
-import React from "react"
+import React from "react";
 // import { action } from "@storybook/addon-actions";
-import MainMenu from "../MainMenu"
-
-
+import MainMenu from "../MainMenu";
 
 export default {
   component: MainMenu,
-  title: 'layout/MainMenu',
+  title: "layout/MainMenu",
 };
-  
-export const defaultView = () => (
-  <MainMenu />
-)
-  
- 
+
+export const defaultView = () => <MainMenu />;


### PR DESCRIPTION
Improves API security with the following measures:

- Use whitelist approach as opposed to blacklisting to prevent unintentional exposure of data
- Disables introspection on production builds (Apollo default)